### PR TITLE
Handle filenames without chapters and skip non directory epub

### DIFF
--- a/kobo-bookmark-extractor.py
+++ b/kobo-bookmark-extractor.py
@@ -67,7 +67,8 @@ if __name__ == '__main__':
         if not content_id.startswith('file:///mnt/onboard/'):
             continue
 
-        book_file, _ = content_id.split('#', 1)
+        book_parts = content_id.split('#', 1)
+        book_file = book_parts[0]
 
         if book_file != previous_book_file:
             if output_descriptor is not None:
@@ -76,8 +77,12 @@ if __name__ == '__main__':
             output_descriptor = open(os.path.basename(book_file[20:-5]) + '.html', 'w')
             output_descriptor.write('<meta charset="UTF-8"><style>body { font-family: sans-serif; }</style>')
 
-        chapter_file, start_container_path_point = start_container_path.split('#', 1)
-        _, end_container_path_point = end_container_path.split('#', 1)
+        try:
+            chapter_file, start_container_path_point = start_container_path.split('#', 1)
+            _, end_container_path_point = end_container_path.split('#', 1)
+        except:
+            print("Failed getting chapter files from {}".format(start_container_path))
+            continue
 
         try:
             with ZipFile(VOLUME + book_file[20:]) as book_zip:
@@ -86,6 +91,8 @@ if __name__ == '__main__':
                     parser.feed(book_chapter.read().decode('utf-8'))
         except KeyError:
             pass
+        except NotADirectoryError as ex:
+            print("Failed opening non directory: '{}'".format(ex.filename))
 
         previous_book_file = book_file
 


### PR DESCRIPTION
Couple of errors encountered on running with my kobo:

Get base name of file without chapter (#)
```bash
file:///mnt/onboard/Real%20World%20Haskell.epub
Traceback (most recent call last):
  File "kobo-bookmark-extractor.py", line 81, in <module>
    chapter_file, start_container_path_point = start_container_path.split('#', 1)
ValueError: not enough values to unpack (expected 2, got 1)
```

NotADirectory:

```bash
Processing file:///mnt/onboard/legacygetmobi7calibre_librarydoragonboru di 01juan  - akira toriyama_7.mobi/shortcover...
Traceback (most recent call last):
  File "kobo-bookmark-extractor.py", line 88, in <module>
    with ZipFile(VOLUME + book_file[20:]) as book_zip:
  File "/usr/local/Cellar/python/3.7.7/Frameworks/Python.framework/Versions/3.7/lib/python3.7/zipfile.py", line 1240, in __init__
    self.fp = io.open(file, filemode)
NotADirectoryError: [Errno 20] Not a directory: '/Volumes/KOBOeReader/legacygetmobi7calibre_librarydoragonboru di 01juan  - akira toriyama_7.mobi/shortcover'
```